### PR TITLE
KDF: add tests for corrupted passphrase/salt/derived-key

### DIFF
--- a/FT/failcases.sh
+++ b/FT/failcases.sh
@@ -329,7 +329,9 @@ verify "ecc_selftest_sign" 2 "ECDSA verify KAT (P-256 curve, SHA2-256) verify fa
 # Test trace: HKDF KAT (PBKDF2 SHA256)
 # Test env var: selftest_pbkdf2.fail
 start_test ${LDDRIVER} "selftest_pbkdf2" "selftest_pbkdf2.fail"
-verify "selftest_pbkdf2" 1 "HKDF KAT (PBKDF2 SHA256)" 1
+verify "selftest_pbkdf2" 3 "HKDF KAT (PBKDF2 SHA256) passphrase" 1
+verify "selftest_pbkdf2" 3 "HKDF KAT (PBKDF2 SHA256) salt" 1
+verify "selftest_pbkdf2" 3 "HKDF KAT (PBKDF2 SHA256) derived key" 1
 
 # Test function: run_mac_selftests
 # Test trace: run_mac_selftests 

--- a/cipher/kdf.c
+++ b/cipher/kdf.c
@@ -1045,10 +1045,6 @@ check_one (int algo, int hash_algo,
   unsigned char key[512]; /* hardcoded to avoid allocation */
   size_t keysize = expectlen;
 
-  /* Skip test with shoter passphrase in FIPS mode.  */
-  if (fips_mode () && passphraselen < 14)
-    return NULL;
-
   if (keysize > sizeof(key))
     return "invalid tests data";
 
@@ -1184,31 +1180,84 @@ selftest_pbkdf2 (int extended, selftest_report_func_t report)
   const char *errtxt;
   int tvidx;
   int fail_fips = gcry_fips_request_failure("selftest_pbkdf2", "fail");
+  char buf[64];
 
   for (tvidx=0; tv[tvidx].desc; tvidx++)
     {
       what = tv[tvidx].desc;
       if (tv[tvidx].disabled)
         continue;
+
+      /* Skip test with shoter passphrase in FIPS mode.  */
+      if (fips_mode() && tv[tvidx].plen < 14)
+	continue;
+
       errtxt = check_one (GCRY_KDF_PBKDF2, tv[tvidx].hashalgo,
                           tv[tvidx].p, tv[tvidx].plen,
                           tv[tvidx].salt, tv[tvidx].saltlen,
                           tv[tvidx].c,
                           tv[tvidx].dk, tv[tvidx].dklen);
 
-      if (fail_fips) {
-        errtxt = "testing failed";
-      }
-
       if (errtxt) {
         KAT_FAILED(0, "HKDF KAT (PBKDF2 SHA256)");
-        if (fail_fips) {
-          continue; /* keep running tests */
-        }
         goto failed;
       } else {
         KAT_SUCCESS(0, "HKDF KAT (PBKDF2 SHA256)");
       }
+
+      if (fail_fips) {
+	/*
+	 * Test corrupting the passphrase
+	 */
+	if (tv[tvidx].plen > sizeof(buf))
+	  continue;
+	memcpy(&buf[0], tv[tvidx].p, tv[tvidx].plen);
+	buf[0] ^= 0x01;
+	if (check_one (GCRY_KDF_PBKDF2, tv[tvidx].hashalgo,
+		       buf, tv[tvidx].plen,
+		       tv[tvidx].salt, tv[tvidx].saltlen,
+		       tv[tvidx].c,
+		       tv[tvidx].dk, tv[tvidx].dklen)) {
+	  KAT_FAILED(0, "HKDF KAT (PBKDF2 SHA256) passphrase");
+	} else {
+	  KAT_SUCCESS(0, "HKDF KAT (PBKDF2 SHA256) passphrase");
+	}
+
+	/*
+	 * Test corrupting the salt
+	 */
+	if (tv[tvidx].saltlen > sizeof(buf))
+	  continue;
+	memcpy(&buf[0], tv[tvidx].salt, tv[tvidx].saltlen);
+	buf[0] ^= 0x01;
+	if (check_one (GCRY_KDF_PBKDF2, tv[tvidx].hashalgo,
+		       tv[tvidx].p, tv[tvidx].plen,
+		       buf, tv[tvidx].saltlen,
+		       tv[tvidx].c,
+		       tv[tvidx].dk, tv[tvidx].dklen)) {
+	  KAT_FAILED(0, "HKDF KAT (PBKDF2 SHA256) salt");
+	} else {
+	  KAT_SUCCESS(0, "HKDF KAT (PBKDF2 SHA256) salt");
+	}
+
+	/*
+	 * Test corrupting the derived key
+	 */
+	if (tv[tvidx].dklen > sizeof(buf))
+	  continue;
+	memcpy(&buf[0], tv[tvidx].dk, tv[tvidx].dklen);
+	buf[0] ^= 0x01;
+	if (check_one (GCRY_KDF_PBKDF2, tv[tvidx].hashalgo,
+		       tv[tvidx].p, tv[tvidx].plen,
+		       tv[tvidx].salt, tv[tvidx].saltlen,
+		       tv[tvidx].c,
+		       buf, tv[tvidx].dklen)) {
+	  KAT_FAILED(0, "HKDF KAT (PBKDF2 SHA256) derived key");
+	} else {
+	  KAT_SUCCESS(0, "HKDF KAT (PBKDF2 SHA256) derived key");
+	}
+      }
+
       if (tvidx >= NUM_TEST_VECTORS - 1 && !extended)
         break;
     }


### PR DESCRIPTION
Add tests for corrupted vectors in KDF and other cleanups